### PR TITLE
商品詳細のサーバーサイド実装

### DIFF
--- a/app/assets/stylesheets/modules/_show.scss
+++ b/app/assets/stylesheets/modules/_show.scss
@@ -45,18 +45,13 @@
               display: flex;
               position: relative;
               li{
-                display: flex;
-                flex-direction: column;
                 width: 560px;
-                align-items: center;
                 margin: 0 auto;
                 img{
                   width: 100%;
                   vertical-align: bottom;
                 }
                 ul{
-                  display: flex;
-                  justify-content: center;
                   margin-top: 10px;
                   li{
                     width: 25%;
@@ -82,6 +77,21 @@
             }
             &-detail{
               font-size: 16px;
+            }
+          }
+          &_buy{
+            padding: 0 24px;
+            margin: 24px 0 24px;
+            &-btn{
+              font-size: 24px;
+              line-height: 60px;
+              display: block;
+              margin-top: 16px;
+              background: #ea352d;
+              color: #fff;
+              text-align: center;
+              font-weight: 600;
+              text-decoration: none;
             }
           }
           &_detail{
@@ -167,6 +177,45 @@
               text-align: center;
             }
             .text-center{
+              font-size: 16px;
+              text-align: center;
+            }
+            &_btn_delete{
+              margin: 16px 0 16px 0;
+              background: #aaa;
+              border: 1px solid #aaa;
+              color: #fff;
+              text-decoration: none;
+              display: block;
+              width: 100%;
+              line-height: 48px;
+              font-size: 14px;
+              border-radius: 4px;
+              text-align: center;
+            }
+          }
+        }
+        details_box{
+          width: 700px;
+          margin: 0 auto;
+          &-list{
+            margin: 24px 0 24px 0;
+            background: #fff;
+            padding: 8px 16px 8px 16px;
+            &_btn_edit{
+              margin: 16px 0 16px 0;
+              background: #ea352d;
+              border: 1px solid #ea352d;
+              color: #fff;
+              text-decoration: none;
+              display: block;
+              width: 100%;
+              line-height: 48px;
+              font-size: 14px;
+              border-radius: 4px;
+              text-align: center;
+            }
+            &-center{
               font-size: 16px;
               text-align: center;
             }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -40,6 +40,10 @@ class ProductsController < ApplicationController
   def edit
   end
 
+  def show
+    @category = Category.find(params[:id])
+  end
+  
   def update
     if @product.update(product_params)
       redirect_to root_path

--- a/app/views/products/_top-page.html.haml
+++ b/app/views/products/_top-page.html.haml
@@ -101,7 +101,7 @@
         .body__pickup_container__products__lists__list
           - @products.each do |product|
             %ul.body__pickup_container__products__lists__list__group
-              = link_to '#', class: "body__pickup_container__products__lists__list__group__link" do
+              = link_to product_path(product.id), class: "body__pickup_container__products__lists__list__group__link" do
                 %li.body__pickup_container__products__lists__list__group__link__images
                   = image_tag product.images.first.image.url, class: "img"
                 %li.body__pickup_container__products__lists__list__group__link__content
@@ -128,7 +128,7 @@
         .body__pickup_container__products__lists__list
           - @products.each do |product|
             %ul.body__pickup_container__products__lists__list__group
-              = link_to '#', class: "body__pickup_container__products__lists__list__group__link" do
+              = link_to product_path(product.id), class: "body__pickup_container__products__lists__list__group__link" do
                 %li.body__pickup_container__products__lists__list__group__link__images
                   = image_tag product.images.first.image.url, class: "img"
                 %li.body__pickup_container__products__lists__list__group__link__content

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -17,24 +17,31 @@
         .main_content_right-top
           .item_box
             %h2.item_box_name
-              products3
+              =@product.name
             .item_box_body
               %ul
                 %li
-                  = image_tag("https://pro-foto.jp/free/img/images_big/yos0006-001.jpg" , class: "item_box_img")
+                  = image_tag @product.images.first.image.url, class: "item_box_img"
                   %ul
                     %li
-                      = image_tag("https://pro-foto.jp/free/img/images_big/yos0002-001.jpg" , class: "iten_box_img")
+                      = image_tag @product.images.second.image.url, class: "iten_box_img"
                     %li
-                      = image_tag("https://pro-foto.jp/free/img/images_big/yos0031-054.jpg" , class: "item_box_img")
+                      = image_tag @product.images.third.image.url, class: "item_box_img"
                     %li
-                      = image_tag("https://pro-foto.jp/free/img/images_big/kid0103-001.jpg" , class: "item_box_img")
+                      -# = image_tag @product.images.first.image.url, class: "item_box_img"
             .item_box_price
-              %span ¥30000
+              %span
+                = @product.price
               .item_box_price-detail
                 %span (税込)
                 %span 送料込み
-            .item_box_detail 親譲りの無鉄砲で小供の時から損ばかりしている。小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
+            .item_box_buy
+            -if user_signed_in? && current_user.id != @product.seller_id
+              = link_to "購入画面に進む", new_order_path, class: "item_box_buy-btn"
+            -unless user_signed_in?
+              = link_to "購入画面に進む", new_user_session_path, class: "item_box_buy-btn"
+            .item_box_detail
+              =@product.explanation
             .item_box_table
               %table
                 %tbody
@@ -44,13 +51,11 @@
                   %tr
                     %th カテゴリー
                     %td
-                      = link_to "#" , class: "item_box_table_link" do
-                        ベビー
-                      = link_to "#" , class: "item_box_table_link" do
-                        アウター
+                      = link_to @category.name
                   %tr
                     %th ブランド
                     %td
+                      =link_to @product.brand
                   %tr
                     %th 商品のサイズ
                     %td
@@ -78,14 +83,15 @@
                   = link_to "#" , class: "optional_btn_link" do
                     = icon('fas','flag',class: "i")
                     不適切な商品の通報
-          .details_box
-            .details_box-list
-              = link_to "#" , class: "details_box-list_btn_edit" do
-                商品の編集
-              %p.text-center
-                or
-              = link_to product_path , class: "details_box-list_btn_delete" do
-                この商品を削除する
+          -if user_signed_in? && current_user.id == @product.seller_id
+            .details_box
+              .details_box-list
+                = link_to "#" , class: "details_box-list_btn_edit" do
+                  商品の編集
+                %p.details_box-list-center
+                  or
+                = link_to "#" , class: "details_box-list_btn_delete" do
+                  この商品を削除する
           .comment_box
             %ul.comment_box_contents
               = form_with class: "new_comment" do |f|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   end
   root to: 'products#index'
 
-  resources :products, only: [:index, :new, :create, :destroy] do
+  resources :products, only: [:index, :new, :create, :destroy, :show] do
     collection do
       get 'get_category_children', defaults: { format: 'json'}
       get 'get_category_grandchildren', defaults: { format: 'json'}


### PR DESCRIPTION
#WHY
出品した商品の詳細がわかることで、購入しようと思う人が増える機能だから。

#WHAT
実装するにあたり、不要なscssを削除しました。
また、詳細画面に新たに購入画面を導入しました。
出品時に登録した情報が見られるようにしました。
ログアウト状態でも商品詳細ページを見ることができるようにしました。
出品者にしか商品の情報編集・削除リンクが踏めないようにしました。
出品者以外にしか商品購入のリンクが踏めないようにしました。