### PR TITLE
商品出品機能の出品中/売却済みの仕分け

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -19,7 +19,9 @@ class OrdersController < ApplicationController
     :customer => @card.customer_id, 
     :currency => 'jpy', 
   )
-  redirect_to root_path 
+
+    @product.update(sales_status: "sold_out")
+    redirect_to root_path 
   end
 
   def set_card

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -22,12 +22,12 @@
               %ul
                 %li
                   = image_tag @product.images.first.image.url, class: "item_box_img"
-                  %ul
-                    %li
-                      = image_tag @product.images.second.image.url, class: "iten_box_img"
-                    %li
-                      = image_tag @product.images.third.image.url, class: "item_box_img"
-                    %li
+                  -# %ul
+                  -#   %li
+                  -#     = image_tag @product.images.second.image.url, class: "item_box_img"
+                  -#   %li
+                  -#     = image_tag @product.images.third.image.url, class: "item_box_img"
+                  -#   %li
                       -# = image_tag @product.images.first.image.url, class: "item_box_img"
             .item_box_price
               %span

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -22,13 +22,6 @@
               %ul
                 %li
                   = image_tag @product.images.first.image.url, class: "item_box_img"
-                  -# %ul
-                  -#   %li
-                  -#     = image_tag @product.images.second.image.url, class: "item_box_img"
-                  -#   %li
-                  -#     = image_tag @product.images.third.image.url, class: "item_box_img"
-                  -#   %li
-                      -# = image_tag @product.images.first.image.url, class: "item_box_img"
             .item_box_price
               %span
                 = @product.price

--- a/db/migrate/20201012061940_create_products.rb
+++ b/db/migrate/20201012061940_create_products.rb
@@ -5,13 +5,13 @@ class CreateProducts < ActiveRecord::Migration[6.0]
       t.text :explanation, null: false
       t.string :brand
       t.integer :price, null: false
+      t.string :sales_status
       t.bigint :category_id, null: false, foreign_key: true
       t.bigint :status_id, null: false, foreign_key: true
       t.bigint :delivery_fee_id, null: false, foreign_key: true
       t.bigint :shipping_area_id, null: false, foreign_key: true
       t.bigint :shipping_day_id, null: false, foreign_key: true
-      t.bigint :buyer_id, foreign_key: true
-      # t.bigint :seller_id, foreign_key: true
+      # t.bigint :buyer_id, foreign_key: true
       t.references :seller, null:false, foreign_key: { to_table: :users }
       t.timestamps null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,12 +54,12 @@ ActiveRecord::Schema.define(version: 2020_11_07_104505) do
     t.text "explanation", null: false
     t.string "brand"
     t.integer "price", null: false
+    t.string "sales_status"
     t.bigint "category_id", null: false
     t.bigint "status_id", null: false
     t.bigint "delivery_fee_id", null: false
     t.bigint "shipping_area_id", null: false
     t.bigint "shipping_day_id", null: false
-    t.bigint "buyer_id"
     t.bigint "seller_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
#WHAT
テーブル上において出品商品の出品中と売却済みの機能追加

#WHY
ユーザーにとって、出品中なのか、完売なのかが、わかると使いやすいため